### PR TITLE
feat(action): Add the first version of generic release action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,7 @@
-name: 'Release'
-description: 'Release Sentry project with Craft'
+name: 'Release prep'
+description: 'Common setup for craft/prepare'
 inputs:
   inputs:
-    ZEUS_API_TOKEN:
-        description: The API token for ZEUS
-        required: true
     version:
       description: Version to release (optional)
       required: false
@@ -23,19 +20,8 @@ runs:
           done
           echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
           fi
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      with:
-          fetch-depth: 20
     - name: Set git user to getsentry-bot
       run: |
           echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
           echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
           echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;
-    - name: craft prepare
-      uses: getsentry/craft@master
-      with:
-          action: prepare
-          version: ${{ env.RELEASE_VERSION }}
-      env:
-          ZEUS_API_TOKEN: ${{ inputs.ZEUS_API_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -10,18 +10,18 @@ runs:
   steps:
     - name: Determine version
       run: |
-          if [[ -n '${{ inputs.version }}' ]]; then
-          echo 'RELEASE_VERSION=${{ inputs.version }}' >> $GITHUB_ENV;
-          else
-          DATE_PART=$(date +'%y.%-m')
-          declare -i PATCH_VERSION=0
-          while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
-              PATCH_VERSION+=1
-          done
-          echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
-          fi
+        if [[ -n '${{ inputs.version }}' ]]; then
+        echo 'RELEASE_VERSION=${{ inputs.version }}' >> $GITHUB_ENV;
+        else
+        DATE_PART=$(date +'%y.%-m')
+        declare -i PATCH_VERSION=0
+        while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
+            PATCH_VERSION+=1
+        done
+        echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
+        fi
     - name: Set git user to getsentry-bot
       run: |
-          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;
+        echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
+        echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
+        echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,41 @@
+name: 'Release'
+description: 'Release Sentry project with Craft'
+inputs:
+  inputs:
+    ZEUS_API_TOKEN:
+        description: The API token for ZEUS
+        required: true
+    version:
+      description: Version to release (optional)
+      required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine version
+      run: |
+          if [[ -n '${{ inputs.version }}' ]]; then
+          echo 'RELEASE_VERSION=${{ inputs.version }}' >> $GITHUB_ENV;
+          else
+          DATE_PART=$(date +'%y.%-m')
+          declare -i PATCH_VERSION=0
+          while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
+              PATCH_VERSION+=1
+          done
+          echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
+          fi
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+          fetch-depth: 20
+    - name: Set git user to getsentry-bot
+      run: |
+          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;
+    - name: craft prepare
+      uses: getsentry/craft@master
+      with:
+          action: prepare
+          version: ${{ env.RELEASE_VERSION }}
+      env:
+          ZEUS_API_TOKEN: ${{ inputs.ZEUS_API_TOKEN }}


### PR DESCRIPTION
This PR and repo serves to consolidate all the distributed release workflows for the `prepare` step:

- https://github.com/getsentry/sentry/blob/ca11465cd4d9c1613ed232a313999bf8f3249272/.github/workflows/release.yml#L33-L63
- https://github.com/getsentry/snuba/blob/77a6bbfc892c442e3a2230ca20cc6bcc5e2620ce/.github/workflows/release.yml#L32-L57
- https://github.com/getsentry/relay/blob/24b85242f914454bd18b744c73e71c91bc572ca8/.github/workflows/release.yml#L33-L61

Notable changes:

 1. Omits the `killswitch` part as that is reserved for publishing, not prepare
 2. Omits the dry-run mode as that is reserved for publishing, not prepare
 3. Uses `GIT_` env variables and `EMAIL` env variable as `git config` does not persist for all cases (see https://github.com/getsentry/relay/runs/1414356448?check_suite_focus=true#step:9:127)
 4. Removes the `sleep 10` workaround as this should either be in publish or ideally, in Craft itself.